### PR TITLE
Align frontend request payload with backend expectations

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -43,9 +43,19 @@ class APIService {
   }
 
   async predictPremiseIndex(data: ModelPredictionRequest): Promise<ModelPredictionResponse> {
+    // FIX: The backend expects snake_case keys. This maps the frontend's camelCase
+    // and PascalCase properties to the required snake_case format.
+    const payload = {
+      temperature: data.temperature,
+      rainfall: data.rainfall,
+      water_content: data.waterContent,
+      rainfall_7d_avg: data.Rainfall_7d_avg,
+      watercontent_7d_avg: data.WaterContent_7d_avg,
+    };
+
     return this.makeRequest<ModelPredictionResponse>('/api/predict', {
       method: 'POST',
-      body: JSON.stringify(data),
+      body: JSON.stringify(payload),
     });
   }
 


### PR DESCRIPTION
The backend's /api/predict endpoint expects JSON keys in snake_case format. The frontend was sending a mix of camelCase and PascalCase, causing a 400 Bad Request error due to missing fields.

This commit modifies the `predictPremiseIndex` function in the API service (`src/services/api.ts`) to transform the request payload keys to snake_case before sending them to the backend. This resolves the data format mismatch and allows the predict endpoint to function correctly.